### PR TITLE
Split up installs and prevent failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,38 @@
 MANDIR=/usr/share/man
 SBINDIR=/usr/sbin
-INIT=$(shell ps -p 1 --no-header | cut -d " " -f 15)
 
 
 all:
 	chmod 755 make-ca help2man
+
+man: all
 	./help2man -s 8 -N ./make-ca -i include.h2m -o make-ca.8
 
-clean:
-	rm -f make-ca.8
+clean: clean_man
 	chmod 0644 help2man
 	chmod 0644 make-ca
 
+clean_man:
+	rm -f make-ca.8
+
 install: all
 	/usr/bin/install -vdm755 $(DESTDIR)$(SBINDIR)
-	/usr/bin/install -vdm755 $(DESTDIR)$(MANDIR)/man8
 	install -vm755 make-ca $(DESTDIR)$(SBINDIR)
+
+install_man: all man
+	/usr/bin/install -vdm755 $(DESTDIR)$(MANDIR)/man8
 	install -vm644 make-ca.8 $(DESTDIR)$(MANDIR)/man8
-	if test "$(INIT)" == "systemd"; then \
+
+install_systemd: all install
+	if test "$(shell ps -p 1 --no-header | cut -d " " -f 15)" == "systemd"; then \
 	    install -vdm755 $(DESTDIR)/etc/systemd/system; \
 	    install -vm644 systemd/* $(DESTDIR)/etc/systemd/system; \
 	fi
 
 uninstall:
 	rm -f $(DESTDIR)$(SBINDIR)/make-ca
+
+uninstall_man:
 	rm -f $(DESTDIR)$(MANDIR)/man8/make-ca.8
 
 .PHONY: all install

--- a/make-ca
+++ b/make-ca
@@ -4,15 +4,17 @@
 # Script to create p11-kit anchors, OpenSSL certs directory, GnuTLS certificate
 # bundle, NSS shared DB, and Java cacerts from upstream certdata.txt and local
 # sources
-# 
+#
 # Authors: DJ Lucas
 #          Bruce Dubbs
+#          Graham Weldon
 
 VERSION="0.7"
+${MAKE_CA_CONF:="/etc/make-ca.conf"}
 
 # Get/set defaults
-if test -f /etc/make-ca.conf; then
-    . /etc/make-ca.conf
+if test -f "${MAKE_CA_CONF}"; then
+    . "${MAKE_CA_CONF}"
 else
     CERTDATA="certdata.txt"
     PKIDIR="/etc/pki"


### PR DESCRIPTION
This is a change that probably requires discussion.

I'd love to be able to use this from within Habitat to assist the update of Java cacerts. However, Habitat doesn't use a standard filesystem layout, to avoid package conflicts, and ensure portability.

This attempts the following:

* Allow configuration file to be specified in the environment
* Don't assume systemd needs checking
* Separate manual installation from make-ca installation

Some things that need consideration:

* Don't assume `ps` distribution contains a `-p` flag (Busybox, for example, doesn't)

Signed-off-by: Graham Weldon <graham@grahamweldon.com>