### PR TITLE
Makefile: add dependency so "make install" won't need -j1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ install_systemd:
 	    install -vm644 systemd/* ${DESTDIR}/lib/systemd/system; \
 	fi
 
-install_man:
+install_man: man
 	install -vdm755 $(DESTDIR)$(MANDIR)/man8
 	install -vm644 make-ca.8 $(DESTDIR)$(MANDIR)/man8
 


### PR DESCRIPTION
Now due to a missing dependency, "make install" will fail if
MAKEFLAGS="-j N" is set to $N > 1$.  Add an additional dependency to
fix it.