### PR TITLE
Don't Use Statically Named tempfiles and Instead Use mktemp

### DIFF
--- a/make-ca
+++ b/make-ca
@@ -759,23 +759,26 @@ CERTBEGINLIST=`grep -n "^# Certificate" "${WORKDIR}/certdata.txt" | \
 
 # Dump individual certs to temp file
 for certbegin in ${CERTBEGINLIST}; do
+  tmpcrtbeg=$(mktemp -p ${TEMPDIR}/certs)
   awk "NR==$certbegin,/^CKA_TRUST_STEP_UP_APPROVED/" "${WORKDIR}/certdata.txt" \
-      > "${TEMPDIR}/certs/${certbegin}.tmp" 
+      > $tmpcrtbeg 
 done
 
-unset CERTBEGINLIST certbegin
+unset tmpcrtbeg CERTBEGINLIST certbegin
 
 for tempfile in ${TEMPDIR}/certs/*.tmp; do
   # Convert to a PEM formated certificate
+  tempcrt=$(mktemp)
+  mv "${tmpcrt}" "${tmpcrt}.crt"
   printf $(awk '/^CKA_VALUE/{flag=1;next}/^END/{flag=0}flag{printf $0}' \
   "${tempfile}") | "${OPENSSL}" x509 -in /dev/stdin -text -inform DER -fingerprint \
-  > tempfile.crt
+  > "${tempcrt}.crt"
 
   # Get individual values for certificates
-  certkey="$(${OPENSSL} x509 -in tempfile.crt -noout -pubkey)"
-  certcer="$(${OPENSSL} x509 -in tempfile.crt)"
-  certtxt="$(${OPENSSL} x509 -in tempfile.crt -noout -text)"
-  keyhash="$(${OPENSSL} x509 -noout -in tempfile.crt -hash)"
+  certkey="$(${OPENSSL} x509 -in ${tempcrt}.crt -noout -pubkey)"
+  certcer="$(${OPENSSL} x509 -in ${tempcrt}.crt)"
+  certtxt="$(${OPENSSL} x509 -in ${tempcrt}.crt -noout -text)"
+  keyhash="$(${OPENSSL} x509 -noout -in ${tempcrt}.crt -hash)"
 
   # Get trust values for the certifcate
   get_trust_values "${tempfile}"
@@ -797,16 +800,17 @@ for tempfile in ${TEMPDIR}/certs/*.tmp; do
 
   # Import all certificates with trust args to the temporary NSS DB
   if test "${WITH_NSS}" == "1"; then
-    write_nss_db ${TEMPDIR}/pki/nssdb tempfile.crt
+    write_nss_db ${TEMPDIR}/pki/nssdb ${tempcrt}.crt
   fi
 
   # Import all certificates with trust args to the java cacerts.p12 file
   if test "${WITH_P12}" == "1"; then
-    write_java_p12 "${TEMPDIR}/ssl/java/cacerts.p12" tempfile.crt
+    write_java_p12 "${TEMPDIR}/ssl/java/cacerts.p12" ${tempcrt}.crt
   fi
 
   # Clean up the directory and environment as we go
-  rm -f tempfile.crt
+  rm -f ${tempcrt}.crt
+  unset tempcrt
   unset keyhash subject count
   unset mozsadistrust mozsmdistrust anchorfile moz_trust
   unset trustlist rejectlist satrust smtrust cstrust catrust
@@ -924,18 +928,21 @@ if test -d "${LOCALDIR}"; then
     write_anchor
 
     # Generate working copy
-    "${OPENSSL}" x509 -in "${cert}" -text -fingerprint > tempfile.crt
+    tempcert=$(mktemp)
+    mv "${tempcert}" "${tempcert}.crt"
+    "${OPENSSL}" x509 -in "${cert}" -text -fingerprint > ${tempcert}.crt
 
     # Add to Shared NSS DB
     if test "${WITH_NSS}" == "1"; then
-      write_nss_db "${DESTDIR}${NSSDB}" tempfile.crt
+      write_nss_db "${DESTDIR}${NSSDB}" ${tempcert}.crt
     fi
 
     # Import certificate (with trust args) into the java cacerts.p12 file
     if test "${WITH_P12}" == "1"; then
-      write_java_p12 "${DESTDIR}${KEYSTORE}/cacerts.p12" tempfile.crt
+      write_java_p12 "${DESTDIR}${KEYSTORE}/cacerts.p12" ${tempcert}.crt
     fi
 
+    unset tempcert
     unset keyhash subject count
     unset mozsadistrust mozsmdistrust anchorfile moz_trust
     unset trustlist rejectlist satrust smtrust cstrust catrust

--- a/make-ca
+++ b/make-ca
@@ -927,7 +927,7 @@ if test -d "${LOCALDIR}"; then
     write_anchor
 
     # Generate working copy
-    tempcert=$(mktemp -t make-ca.XXXXXXXX.pem)
+    tempcert=$(mktemp -p ${TEMPDIR}/certs -t make-ca.XXXXXXXX.pem)
     "${OPENSSL}" x509 -in "${cert}" -text -fingerprint > ${tempcert}
 
     # Add to Shared NSS DB

--- a/make-ca
+++ b/make-ca
@@ -766,10 +766,10 @@ done
 
 unset tmpcrtbeg CERTBEGINLIST certbegin
 
-for tempfile in ${TEMPDIR}/certs/*.tmp; do
+for tempfile in ${TEMPDIR}/certs/tmp.*; do
   # Convert to a PEM formated certificate
   tempcrt=$(mktemp)
-  mv "${tmpcrt}" "${tmpcrt}.crt"
+  mv "${tempcrt}" "${tempcrt}.crt"
   printf $(awk '/^CKA_VALUE/{flag=1;next}/^END/{flag=0}flag{printf $0}' \
   "${tempfile}") | "${OPENSSL}" x509 -in /dev/stdin -text -inform DER -fingerprint \
   > "${tempcrt}.crt"

--- a/make-ca
+++ b/make-ca
@@ -759,26 +759,25 @@ CERTBEGINLIST=`grep -n "^# Certificate" "${WORKDIR}/certdata.txt" | \
 
 # Dump individual certs to temp file
 for certbegin in ${CERTBEGINLIST}; do
-  tmpcrtbeg=$(mktemp -p ${TEMPDIR}/certs)
+  tmpcrtbeg=$(mktemp -p ${TEMPDIR}/certs -t make-ca.XXXXXXXX.tmp)
   awk "NR==$certbegin,/^CKA_TRUST_STEP_UP_APPROVED/" "${WORKDIR}/certdata.txt" \
-      > $tmpcrtbeg 
+      > $tmpcrtbeg
 done
 
-unset tmpcrtbeg CERTBEGINLIST certbegin
+unset CERTBEGINLIST certbegin
 
-for tempfile in ${TEMPDIR}/certs/tmp.*; do
+for tempfile in ${TEMPDIR}/certs/*.tmp; do
   # Convert to a PEM formated certificate
-  tempcrt=$(mktemp)
-  mv "${tempcrt}" "${tempcrt}.crt"
+  tempcrt=${tempfile%.tmp}.pem
   printf $(awk '/^CKA_VALUE/{flag=1;next}/^END/{flag=0}flag{printf $0}' \
   "${tempfile}") | "${OPENSSL}" x509 -in /dev/stdin -text -inform DER -fingerprint \
-  > "${tempcrt}.crt"
+  > "${tempcrt}"
 
   # Get individual values for certificates
-  certkey="$(${OPENSSL} x509 -in ${tempcrt}.crt -noout -pubkey)"
-  certcer="$(${OPENSSL} x509 -in ${tempcrt}.crt)"
-  certtxt="$(${OPENSSL} x509 -in ${tempcrt}.crt -noout -text)"
-  keyhash="$(${OPENSSL} x509 -noout -in ${tempcrt}.crt -hash)"
+  certkey="$(${OPENSSL} x509 -in ${tempcrt} -noout -pubkey)"
+  certcer="$(${OPENSSL} x509 -in ${tempcrt})"
+  certtxt="$(${OPENSSL} x509 -in ${tempcrt} -noout -text)"
+  keyhash="$(${OPENSSL} x509 -noout -in ${tempcrt} -hash)"
 
   # Get trust values for the certifcate
   get_trust_values "${tempfile}"
@@ -800,16 +799,16 @@ for tempfile in ${TEMPDIR}/certs/tmp.*; do
 
   # Import all certificates with trust args to the temporary NSS DB
   if test "${WITH_NSS}" == "1"; then
-    write_nss_db ${TEMPDIR}/pki/nssdb ${tempcrt}.crt
+    write_nss_db ${TEMPDIR}/pki/nssdb ${tempcrt}
   fi
 
   # Import all certificates with trust args to the java cacerts.p12 file
   if test "${WITH_P12}" == "1"; then
-    write_java_p12 "${TEMPDIR}/ssl/java/cacerts.p12" ${tempcrt}.crt
+    write_java_p12 "${TEMPDIR}/ssl/java/cacerts.p12" ${tempcrt}
   fi
 
   # Clean up the directory and environment as we go
-  rm -f ${tempcrt}.crt
+  rm -f ${tempcrt}
   unset tempcrt
   unset keyhash subject count
   unset mozsadistrust mozsmdistrust anchorfile moz_trust
@@ -928,20 +927,20 @@ if test -d "${LOCALDIR}"; then
     write_anchor
 
     # Generate working copy
-    tempcert=$(mktemp)
-    mv "${tempcert}" "${tempcert}.crt"
-    "${OPENSSL}" x509 -in "${cert}" -text -fingerprint > ${tempcert}.crt
+    tempcert=$(mktemp -t make-ca.XXXXXXXX.pem)
+    "${OPENSSL}" x509 -in "${cert}" -text -fingerprint > ${tempcert}
 
     # Add to Shared NSS DB
     if test "${WITH_NSS}" == "1"; then
-      write_nss_db "${DESTDIR}${NSSDB}" ${tempcert}.crt
+      write_nss_db "${DESTDIR}${NSSDB}" ${tempcert}
     fi
 
     # Import certificate (with trust args) into the java cacerts.p12 file
     if test "${WITH_P12}" == "1"; then
-      write_java_p12 "${DESTDIR}${KEYSTORE}/cacerts.p12" ${tempcert}.crt
+      write_java_p12 "${DESTDIR}${KEYSTORE}/cacerts.p12" ${tempcert}
     fi
 
+    rm -f ${tempcert}
     unset tempcert
     unset keyhash subject count
     unset mozsadistrust mozsmdistrust anchorfile moz_trust


### PR DESCRIPTION
What my proposed PR does is instead of outputting some content to statically named files, it first creates the files using `mktemp`, stores the file path in a variable much like the temporary directory, and then works with those instead. Some get renamed to *.crt. It seemed to run just fine.

Why do I propose this PR? DJ Lucas mentioned this is an issue that should probably be addressed on my last PR #30. 