### PR TITLE
Do not make anchors untrusted because the system date is after the CKA_NSS_*_DISTRUST_AFTER dates

### DIFF
--- a/make-ca
+++ b/make-ca
@@ -372,12 +372,6 @@ function convert_moz_distrust(){
     fi
   elif test "${val}" == "MULTILINE_OCTAL"; then
     mozsadistrust=`printf $(grep -A1 "CKA_NSS_SERVER_DISTRUST_AFTER" "${1}" | tail -n1)`
-    # FIXME - Work around P11-kit breakage
-    cdate=$(date -u +%y%m%d)
-    mozsadate=${mozsadistrust::6}
-    if test ${cdate} -gt ${mozsadate}; then
-      satrust="p"
-    fi
   else
     mozsadistrust="UNKNOWN"
   fi
@@ -393,12 +387,6 @@ function convert_moz_distrust(){
     fi
   elif test "${val}" == "MULTILINE_OCTAL"; then
     mozsmdistrust=`printf $(grep -A1 "CKA_NSS_EMAIL_DISTRUST_AFTER" "${1}" | tail -n1)`
-    # FIXME - Work around P11-kit breakage
-    cdate=$(date -u +%y%m%d)
-    mozsmdate=${mozsmdistrust::6}
-    if test ${cdate} -gt ${mozsmdate}; then
-      smtrust="p"
-    fi
   else
     mozsmdistrust="UNKNOWN"
   fi


### PR DESCRIPTION
Will fix #32.

This is a working in progress.

This indeed fix the fidelity.com access but we need to test if a certificate will be correctly rejected if it's really issued after the `CKA_NSS_*_DISTRUST_AFTER` date.

And we need to make the decision for what to do with packages not using p11-kit (notably OpenSSL) as we cannot encode `CKA_NSS_*_DISTRUST_AFTER` dates in X509: should we just ignore the `CKA_NSS_*_DISTRUST_AFTER` dates (overly-permissive) or not to export a certificate with a `CKA_NSS_*_DISTRUST_AFTER` date > system date as X509 (overly-restrictive)?