### PR TITLE
Update the URL in make-ca.conf.dist to match the one in make-ca.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.16.1   - Change /etc/make-ca/make-ca.conf.dist to use the URL that we changed
+           the make-ca tool to in version 1.16. Thanks goes to Andrew K. from
+           AVS ISP for the report privately.
 1.16     - Change the certificate root for Mozilla to Let's Encrypt
            and adjust the URL to use https://hg-edge.mozilla.org instead
            of https://hg.mozilla.org. This is required because hg.mozilla.org

--- a/make-ca.conf.dist
+++ b/make-ca.conf.dist
@@ -19,7 +19,7 @@ KEYSTORE="${PKIDIR}/tls/java"
 NSSDB="${PKIDIR}/nssdb"
 LOCALDIR="${SSLDIR}/local"
 DESTDIR=""
-URL="https://hg.mozilla.org/projects/nss/raw-file/tip/lib/ckfw/builtins/certdata.txt"
+URL="https://hg-edge.mozilla.org/projects/nss/raw-file/tip/lib/ckfw/builtins/certdata.txt"
 
 # Source must be downloaded over https
 # Valid urls for download are below


### PR DESCRIPTION
When we updated the make-ca utility to change the URL for the certificates, we forgot to update the URL in make-ca.conf.dist. Most of the editors don't use make-ca.conf so we didn't run into the problem during the release of make-ca-1.16.

Thanks goes to Andrew K. from AVS ISP for the report.